### PR TITLE
Modify add command

### DIFF
--- a/src/main/java/seedu/bitebuddy/model/foodplace/Address.java
+++ b/src/main/java/seedu/bitebuddy/model/foodplace/Address.java
@@ -54,7 +54,7 @@ public class Address {
         }
 
         Address otherAddress = (Address) other;
-        return value.equals(otherAddress.value);
+        return value.equalsIgnoreCase(otherAddress.value);
     }
 
     @Override

--- a/src/main/java/seedu/bitebuddy/model/foodplace/Email.java
+++ b/src/main/java/seedu/bitebuddy/model/foodplace/Email.java
@@ -68,7 +68,7 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
-        return value.equals(otherEmail.value);
+        return value.equalsIgnoreCase(otherEmail.value);
     }
 
     @Override

--- a/src/main/java/seedu/bitebuddy/model/foodplace/Foodplace.java
+++ b/src/main/java/seedu/bitebuddy/model/foodplace/Foodplace.java
@@ -71,7 +71,10 @@ public class Foodplace {
         }
 
         return otherFoodplace != null
-                && otherFoodplace.getName().equals(getName());
+                && otherFoodplace.getName().equals(getName())
+                && otherFoodplace.getAddress().equals(getAddress())
+                && otherFoodplace.getEmail().equals(getEmail())
+                && otherFoodplace.getPhone().equals(getPhone());
     }
 
     /**

--- a/src/main/java/seedu/bitebuddy/model/foodplace/Name.java
+++ b/src/main/java/seedu/bitebuddy/model/foodplace/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateFoodplaceAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateFoodplaceAddressBook.json
@@ -8,7 +8,7 @@
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
-    "email": "pauline@example.com",
-    "address": "4th street"
+    "email": "Alice@example.com",
+    "address": "123, jurong west ave 6, #08-111"
   } ]
 }

--- a/src/test/java/seedu/bitebuddy/model/AddressBookTest.java
+++ b/src/test/java/seedu/bitebuddy/model/AddressBookTest.java
@@ -46,7 +46,7 @@ public class AddressBookTest {
     @Test
     public void resetData_withDuplicateFoodplaces_throwsDuplicateFoodplaceException() {
         // Two foodplaces with the same identity fields
-        Foodplace editedAlice = new FoodplaceBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Foodplace editedAlice = new FoodplaceBuilder(ALICE).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Foodplace> newFoodplaces = Arrays.asList(ALICE, editedAlice);
         AddressBookStub newData = new AddressBookStub(newFoodplaces);
@@ -73,7 +73,7 @@ public class AddressBookTest {
     @Test
     public void hasFoodplace_foodplaceWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addFoodplace(ALICE);
-        Foodplace editedAlice = new FoodplaceBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Foodplace editedAlice = new FoodplaceBuilder(ALICE).withTags(VALID_TAG_HUSBAND)
                 .build();
         assertTrue(addressBook.hasFoodplace(editedAlice));
     }

--- a/src/test/java/seedu/bitebuddy/model/foodplace/FoodplaceTest.java
+++ b/src/test/java/seedu/bitebuddy/model/foodplace/FoodplaceTest.java
@@ -33,17 +33,16 @@ public class FoodplaceTest {
         assertFalse(ALICE.isSameFoodplace(null));
 
         // same name, all other attributes different -> returns true
-        Foodplace editedAlice = new FoodplaceBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+        Foodplace editedAlice = new FoodplaceBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSameFoodplace(editedAlice));
 
         // different name, all other attributes same -> returns false
         editedAlice = new FoodplaceBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSameFoodplace(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Foodplace editedBob = new FoodplaceBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameFoodplace(editedBob));
+        assertTrue(BOB.isSameFoodplace(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";

--- a/src/test/java/seedu/bitebuddy/model/foodplace/UniqueFoodplaceListTest.java
+++ b/src/test/java/seedu/bitebuddy/model/foodplace/UniqueFoodplaceListTest.java
@@ -42,7 +42,7 @@ public class UniqueFoodplaceListTest {
     @Test
     public void contains_foodplaceWithSameIdentityFieldsInList_returnsTrue() {
         uniqueFoodplaceList.add(ALICE);
-        Foodplace editedAlice = new FoodplaceBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Foodplace editedAlice = new FoodplaceBuilder(ALICE).withTags(VALID_TAG_HUSBAND)
                 .build();
         assertTrue(uniqueFoodplaceList.contains(editedAlice));
     }


### PR DESCRIPTION
Duplicate entries are now detected when all four fields (name, address, phone number, and email) match, ignoring case.
This ensures that duplicates are identified consistently even if users enter values with different capitalisation.

Closes #49 