### PR TITLE
Add autofix for invalid manual edit on note wishlist blacklist

### DIFF
--- a/src/main/java/seedu/bitebuddy/MainApp.java
+++ b/src/main/java/seedu/bitebuddy/MainApp.java
@@ -176,15 +176,34 @@ public class MainApp extends Application {
     public void start(Stage primaryStage) {
         logger.log(Level.INFO, "Starting BiteBuddy {0}", MainApp.VERSION);
         ui.start(primaryStage);
+        // After UI is up, show auto-fix summary if storage reported fixes during load.
+        if (storage != null && ui != null) {
+            try {
+                java.util.List<seedu.bitebuddy.storage.AutoFixRecord> fixes = storage.getLastAutoFixes();
+                ui.showAutoFixSummary(fixes);
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Unable to show auto-fix summary: {0}", e.getMessage());
+            }
+        }
     }
 
     @Override
     public void stop() {
         logger.info("============================ [ Stopping BiteBuddy ] =============================");
         try {
-            storage.saveUserPrefs(model.getUserPrefs());
+            if (storage != null && model != null) {
+                // If there were auto-fixes during load, save the repaired address book back to json.
+                java.util.List<seedu.bitebuddy.storage.AutoFixRecord> fixes = storage.getLastAutoFixes();
+                if (fixes != null && !fixes.isEmpty()) {
+                    logger.info("Auto-fixes detected on load; saving repaired address book to disk.");
+                    storage.saveAddressBook(model.getAddressBook());
+                }
+                // Save user preferences.
+                storage.saveUserPrefs(model.getUserPrefs());
+            }
         } catch (IOException e) {
-            logger.log(Level.SEVERE, "Failed to save preferences {0}", StringUtil.getDetails(e));
+            logger.log(Level.SEVERE, "Failed to save data on exit: {0}", StringUtil.getDetails(e));
         }
     }
+
 }

--- a/src/main/java/seedu/bitebuddy/model/foodplace/Note.java
+++ b/src/main/java/seedu/bitebuddy/model/foodplace/Note.java
@@ -19,11 +19,16 @@ public class Note {
     public final String value;
 
     /**
-     * Constructs Note object, the string can be empty
+     * Constructs Note object, the string can be empty or consist only of whitespace which is treated as empty.
      * @param note the note for a foodplace
      */
     public Note(String note) {
         requireNonNull(note);
+        // Treat whitespace-only notes (e.g. "   ") as empty notes.
+        if (note.trim().isEmpty()) {
+            this.value = "";
+            return;
+        }
         checkArgument(isValidNote(note), MESSAGE_CONSTRAINTS);
         this.value = note;
     }

--- a/src/main/java/seedu/bitebuddy/storage/AddressBookStorage.java
+++ b/src/main/java/seedu/bitebuddy/storage/AddressBookStorage.java
@@ -42,4 +42,9 @@ public interface AddressBookStorage {
      */
     void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException;
 
+    /**
+     * Returns the list of auto-fix records collected during the last call to {@link ReadOnlyAddressBook}.
+     * Implementations may return an empty list if no auto-fixes were applied.
+     */
+    java.util.List<AutoFixRecord> getLastAutoFixes();
 }

--- a/src/main/java/seedu/bitebuddy/storage/AutoFixRecord.java
+++ b/src/main/java/seedu/bitebuddy/storage/AutoFixRecord.java
@@ -1,0 +1,55 @@
+package seedu.bitebuddy.storage;
+
+import java.util.Objects;
+
+/**
+ * Represents a small record of an automatic fix applied when loading data from JSON.
+ */
+public class AutoFixRecord {
+    private final String foodplaceName;
+    private final String fieldChanged;
+
+    /**
+     * Constructs an AutoFixRecord with the given foodplace name and field changed.
+     *
+     * @param foodplaceName the name of the foodplace
+     * @param fieldChanged the field that was auto-fixed (changed)
+     */
+    public AutoFixRecord(String foodplaceName, String fieldChanged) {
+        this.foodplaceName = foodplaceName;
+        this.fieldChanged = fieldChanged;
+    }
+
+    public String getFoodplaceName() {
+        return foodplaceName;
+    }
+
+    public String getFieldChanged() {
+        return fieldChanged;
+    }
+
+    @Override
+    public String toString() {
+        return foodplaceName + ": " + fieldChanged;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof AutoFixRecord)) {
+            return false;
+        }
+
+        AutoFixRecord other = (AutoFixRecord) o;
+        return Objects.equals(foodplaceName, other.foodplaceName) && Objects.equals(fieldChanged, other.fieldChanged);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(foodplaceName, fieldChanged);
+    }
+}
+

--- a/src/main/java/seedu/bitebuddy/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/bitebuddy/storage/JsonSerializableAddressBook.java
@@ -47,9 +47,13 @@ class JsonSerializableAddressBook {
      * @throws IllegalValueException if there were any data constraints violated.
      */
     public AddressBook toModelType() throws IllegalValueException {
+        return toModelType(new java.util.ArrayList<>());
+    }
+
+    public AddressBook toModelType(java.util.List<AutoFixRecord> fixes) throws IllegalValueException {
         AddressBook addressBook = new AddressBook();
         for (JsonAdaptedFoodplace jsonAdaptedFoodplace : foodplaces) {
-            Foodplace foodplace = jsonAdaptedFoodplace.toModelType();
+            Foodplace foodplace = jsonAdaptedFoodplace.toModelType(fixes);
             if (addressBook.hasFoodplace(foodplace)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_FOODPLACE);
             }

--- a/src/main/java/seedu/bitebuddy/storage/StorageManager.java
+++ b/src/main/java/seedu/bitebuddy/storage/StorageManager.java
@@ -76,4 +76,9 @@ public class StorageManager implements Storage {
         addressBookStorage.saveAddressBook(addressBook, filePath);
     }
 
+    @Override
+    public java.util.List<AutoFixRecord> getLastAutoFixes() {
+        return addressBookStorage.getLastAutoFixes();
+    }
+
 }

--- a/src/main/java/seedu/bitebuddy/ui/Ui.java
+++ b/src/main/java/seedu/bitebuddy/ui/Ui.java
@@ -10,4 +10,9 @@ public interface Ui {
     /** Starts the UI (and the App).  */
     void start(Stage primaryStage);
 
+    /**
+     * Optional hook to display auto-fix summary detected during data load.
+     * Default implementation does nothing.
+     */
+    void showAutoFixSummary(java.util.List<seedu.bitebuddy.storage.AutoFixRecord> fixes);
 }

--- a/src/main/java/seedu/bitebuddy/ui/UiManager.java
+++ b/src/main/java/seedu/bitebuddy/ui/UiManager.java
@@ -85,4 +85,18 @@ public class UiManager implements Ui {
         System.exit(1);
     }
 
+    @Override
+    public void showAutoFixSummary(java.util.List<seedu.bitebuddy.storage.AutoFixRecord> fixes) {
+        if (fixes == null || fixes.isEmpty()) {
+            return;
+        }
+        StringBuilder content = new StringBuilder();
+        content.append("Auto-fixes applied: ").append(fixes.size()).append("\n\n");
+        for (seedu.bitebuddy.storage.AutoFixRecord r : fixes) {
+            content.append(r.toString()).append("\n");
+        }
+        showAlertDialogAndWait(Alert.AlertType.INFORMATION, "Data Auto-Fix Summary",
+                "Some data issues were detected and automatically fixed.", content.toString());
+    }
+
 }

--- a/src/test/data/JsonSerializableAddressBookTest/conflictingWishlistBlacklist.json
+++ b/src/test/data/JsonSerializableAddressBookTest/conflictingWishlistBlacklist.json
@@ -1,0 +1,19 @@
+{
+  "foodplaces": [
+    {
+      "name": "Place A",
+      "phone": "12345678",
+      "email": "",
+      "address": "1 Road",
+      "timing": "09:00-18:00",
+      "cuisine": "Thai",
+      "tags": [],
+      "note": "",
+      "rate": 0,
+      "wishlist": true,
+      "blacklist": true,
+      "isPinned": false
+    }
+  ]
+}
+

--- a/src/test/data/JsonSerializableAddressBookTest/nullNoteFoodplaceAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/nullNoteFoodplaceAddressBook.json
@@ -1,0 +1,19 @@
+{
+  "foodplaces": [
+    {
+      "name": "Place B",
+      "phone": "87654321",
+      "email": "",
+      "address": "2 Lane",
+      "timing": "09:00-18:00",
+      "cuisine": "Korean",
+      "tags": [],
+      "note": null,
+      "rate": 0,
+      "wishlist": false,
+      "blacklist": false,
+      "isPinned": false
+    }
+  ]
+}
+

--- a/src/test/java/seedu/bitebuddy/storage/JsonAdaptedFoodplaceTest.java
+++ b/src/test/java/seedu/bitebuddy/storage/JsonAdaptedFoodplaceTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.bitebuddy.commons.exceptions.IllegalValueException;
 import seedu.bitebuddy.model.foodplace.Address;
-import seedu.bitebuddy.model.foodplace.Blacklist;
 import seedu.bitebuddy.model.foodplace.Cuisine;
 import seedu.bitebuddy.model.foodplace.Email;
 import seedu.bitebuddy.model.foodplace.Foodplace;
@@ -24,7 +23,6 @@ import seedu.bitebuddy.model.foodplace.Phone;
 import seedu.bitebuddy.model.foodplace.Pinned;
 import seedu.bitebuddy.model.foodplace.Rate;
 import seedu.bitebuddy.model.foodplace.Timing;
-import seedu.bitebuddy.model.foodplace.Wishlist;
 
 public class JsonAdaptedFoodplaceTest {
     private static final String INVALID_NAME = "R@chel";
@@ -162,14 +160,17 @@ public class JsonAdaptedFoodplaceTest {
     }
 
     @Test
-    public void toModelType_nullNote_throwsIllegalValueException() {
-        // Null note is considered a kind of invalid note as well
+    public void toModelType_nullNote_sanitizedToEmpty() {
         JsonAdaptedFoodplace foodplace =
                 new JsonAdaptedFoodplace(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_TIMING, VALID_CUISINE, VALID_TAGS, null, VALID_RATING, VALID_WISHLIST,
                         VALID_BLACKLIST, VALID_PINNED);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Note.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, foodplace::toModelType);
+        try {
+            Foodplace model = foodplace.toModelType();
+            assertEquals("", model.getNote().value);
+        } catch (IllegalValueException e) {
+            fail();
+        }
     }
 
     @Test
@@ -258,21 +259,29 @@ public class JsonAdaptedFoodplaceTest {
     }
 
     @Test
-    public void toModelType_nullWishlist_throwsIllegalValueException() {
+    public void toModelType_nullWishlist_defaultsToFalse() {
         JsonAdaptedFoodplace foodplace =
                 new JsonAdaptedFoodplace(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TIMING,
                         VALID_CUISINE, VALID_TAGS, VALID_NOTE, VALID_RATING, null, VALID_BLACKLIST, VALID_PINNED);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Wishlist.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, foodplace::toModelType);
+        try {
+            Foodplace model = foodplace.toModelType();
+            assertEquals(false, model.getWishlist().isWishlisted());
+        } catch (IllegalValueException e) {
+            fail();
+        }
     }
 
     @Test
-    public void toModelType_nullBlacklist_throwsIllegalValueException() {
+    public void toModelType_nullBlacklist_defaultsToFalse() {
         JsonAdaptedFoodplace foodplace =
                 new JsonAdaptedFoodplace(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TIMING,
                         VALID_CUISINE, VALID_TAGS, VALID_NOTE, VALID_RATING, VALID_WISHLIST, null, VALID_PINNED);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Blacklist.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, foodplace::toModelType);
+        try {
+            Foodplace model = foodplace.toModelType();
+            assertEquals(false, model.getBlacklist().isBlacklisted());
+        } catch (IllegalValueException e) {
+            fail();
+        }
     }
 
     @Test

--- a/src/test/java/seedu/bitebuddy/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/bitebuddy/storage/JsonSerializableAddressBookTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import seedu.bitebuddy.commons.exceptions.IllegalValueException;
 import seedu.bitebuddy.commons.util.JsonUtil;
 import seedu.bitebuddy.model.AddressBook;
+import seedu.bitebuddy.model.foodplace.Foodplace;
 import seedu.bitebuddy.testutil.TypicalFoodplace;
 
 public class JsonSerializableAddressBookTest {
@@ -23,6 +24,10 @@ public class JsonSerializableAddressBookTest {
             TEST_DATA_FOLDER.resolve("invalidFoodplaceAddressBook.json");
     private static final Path DUPLICATE_FOODPLACES_FILE =
             TEST_DATA_FOLDER.resolve("duplicateFoodplaceAddressBook.json");
+    private static final Path CONFLICTING_WISHLIST_BLACKLIST_FILE =
+            TEST_DATA_FOLDER.resolve("conflictingWishlistBlacklist.json");
+    private static final Path NULL_NOTE_FILE =
+            TEST_DATA_FOLDER.resolve("nullNoteFoodplaceAddressBook.json");
 
     @Test
     public void toModelType_typicalFoodplacesFile_success() throws Exception {
@@ -47,6 +52,25 @@ public class JsonSerializableAddressBookTest {
                 JsonSerializableAddressBook.class).get();
         assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_FOODPLACE,
                 dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_conflictingWishlistBlacklist_autofixesToNoStatus() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(CONFLICTING_WISHLIST_BLACKLIST_FILE,
+                JsonSerializableAddressBook.class).get();
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        Foodplace fp = addressBookFromFile.getFoodplaceList().get(0);
+        assertEquals(false, fp.getWishlist().isWishlisted());
+        assertEquals(false, fp.getBlacklist().isBlacklisted());
+    }
+
+    @Test
+    public void toModelType_nullNote_autofixesToEmptyNote() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(NULL_NOTE_FILE,
+                JsonSerializableAddressBook.class).get();
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        Foodplace fp = addressBookFromFile.getFoodplaceList().get(0);
+        assertEquals("", fp.getNote().value);
     }
 
 }

--- a/src/test/java/seedu/bitebuddy/testutil/TestStubs.java
+++ b/src/test/java/seedu/bitebuddy/testutil/TestStubs.java
@@ -3,12 +3,14 @@ package seedu.bitebuddy.testutil;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 
 import seedu.bitebuddy.commons.exceptions.DataLoadingException;
 import seedu.bitebuddy.model.ReadOnlyAddressBook;
 import seedu.bitebuddy.model.ReadOnlyUserPrefs;
 import seedu.bitebuddy.model.UserPrefs;
+import seedu.bitebuddy.storage.AutoFixRecord;
 import seedu.bitebuddy.storage.Storage;
 import seedu.bitebuddy.ui.Ui;
 
@@ -94,6 +96,11 @@ public final class TestStubs {
                 throw new IOException("stub save prefs failure");
             }
         }
+
+        @Override
+        public java.util.List<seedu.bitebuddy.storage.AutoFixRecord> getLastAutoFixes() {
+            return new java.util.ArrayList<>();
+        }
     }
 
     /**
@@ -120,6 +127,11 @@ public final class TestStubs {
         @Override
         public void start(javafx.stage.Stage primaryStage) {
             started = true;
+        }
+
+        @Override
+        public void showAutoFixSummary(List<AutoFixRecord> fixes) {
+            return;
         }
     }
 


### PR DESCRIPTION
Closes #160 and closes #161

Suppose a manual edit is done to set a foodplace's `wishlist` and `blacklist` status to `true` and set a note with `"    "`
GUI for auto fix popup:
<img width="905" height="731" alt="image" src="https://github.com/user-attachments/assets/aa8b446c-faa7-4ebc-93b3-0eb88a338dc7" />


**Please take note that only validation is done for `note` `wishlist` and `blacklist`**
**The default behaviour for other invalid fields is to create an empty address book (this has always been the expected behaviour before this PR)**
