### PR TITLE
Remove implementations details from Use Cases

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -593,11 +593,13 @@ Guarantees: A rating between 1–10 is stored and existing rating is overwritten
 
 **Extensions**
 
-* 3a. The given index is 0.
-    * 3a1. BiteBuddy removes the rating from the foodplace.
+* 3a. The given index is invalid.
+    * 3a1. BiteBuddy shows an error for invalid index.
 
-* 3b. The given index is invalid.
-    * 3b1. BiteBuddy shows an error for invalid index.
+      Use case ends.
+
+* 3b. The given rating is 0.
+    * 3b1. BiteBuddy removes the rating from the foodplace.
 
       Use case ends.
 


### PR DESCRIPTION
Closes #310 -> remove all implementation details

Closes #283 -> added a new extension for `0` input in `rate` use case