### PR TITLE
Fix model class diagram view

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -153,7 +153,7 @@ The `Model` component,
 
 **API** : [`Storage.java`](https://github.com/AY2526S1-CS2103T-W14-2/tp/blob/master/src/main/java/seedu/bitebuddy/storage/Storage.java)
 
-<puml src="diagrams/StorageClassDiagram.puml" width="550"/>
+<puml src="diagrams/StorageClassDiagram.puml" width="550" />
 
 The `Storage` component,
 * can save both address book data and user preference data in JSON format, and read them back into corresponding objects.


### PR DESCRIPTION
Previously removed width restriction on the wrong diagram. This PR restores the original width for the storage diagram and correctly removes width restriction for the cluttered model class diagram.
- Closes #304 
